### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 ## DOWN
 ![IMAGE][1]
 
-##UP
+## UP
 ![IMAGE][2]
 
-##DOWN_AND_UP
+## DOWN_AND_UP
 ![IMAGE][4]
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
